### PR TITLE
Some help

### DIFF
--- a/packaging/sdeb/constants.go
+++ b/packaging/sdeb/constants.go
@@ -46,7 +46,7 @@ binary: binary-arch`
 	TEMPLATE_SOURCEDEB_CONTROL = `Source: {{.PackageName}}
 Build-Depends: {{.BuildDepends}}
 Priority: {{.Priority}}
-Maintainer: {{.Maintainer}}
+Maintainer: {{.Maintainer}} <{{.MaintainerEmail}}>
 Standards-Version: {{.StandardsVersion}}
 Section: {{.Section}}
 

--- a/tasks/pkg-source.go
+++ b/tasks/pkg-source.go
@@ -76,7 +76,7 @@ func init() {
 		TASK_PKG_SOURCE,
 		"Build a source package. Currently only supports 'source deb' format for Debian/Ubuntu Linux.",
 		runTaskPkgSource,
-		map[string]interface{}{"metadata": map[string]interface{}{"maintainer": "unknown", "maintainerEmail": "unknown@example.com"}, "metadata-deb": map[string]interface{}{"Depends": "", "Build-Depends": "debhelper (>=4.0.0), golang-go, gcc"}, "templateDir": "debian-templates", "rmtemp": true}})
+		map[string]interface{}{"metadata": map[string]interface{}{"maintainer": "unknown", "maintainerEmail": "unknown@example.com"}, "metadata-deb": map[string]interface{}{"Depends": "", "Priority": "extra", "Section": "devel", "Status": "unreleased", "Build-Depends": "debhelper (>= 9.1.0), golang-go"}, "templateDir": "debian-templates", "rmtemp": true}})
 }
 
 func runTaskPkgSource(tp TaskParams) (err error) {


### PR DESCRIPTION
First commit shows the vars which should be allowed to be configured generally.

``` json
{
  "Depends": "",
  "Priority": "extra",
  "Section": "devel",
  "Status": "unreleased",
  "Build-Depends": "debhelper (>= 9.1.0), golang-go"
}
```

All the above vars should be able to be overwritten. I hope you do this soon.

---

I need the source.changes file to upload the source package to launchpad. This is the process I follow:

``` bash
$ cd src/github.com/pksunkara/whitespaces
$ goxc pkg-source
$ cd 1.0.0/source-deb

$ tar -xvf *.debian.tar.gz
$ debuild -S -sa

$ dput ../*_source.changes
```

But when I upload the source.changes to launchpad, it doesn't compile.
