### PR TITLE
[downloads-page] make Version available so generated links can include version

### DIFF
--- a/tasks/downloads-page.go
+++ b/tasks/downloads-page.go
@@ -18,7 +18,6 @@ package tasks
 
 import (
 	htemplate "html/template"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,7 +167,6 @@ func downloadsWalkFunc(fullPath string, Version string, fi2 os.FileInfo, err err
 	category := getCategory(relativePath)
 
 	//log.Printf("Adding: %s", relativePath)
-	log.Printf("Adding: %s", Version)
 	download := Download{text, Version, relativePath}
 	v, ok := report.Categories[category]
 	var existing []Download


### PR DESCRIPTION
I am placing my generated downloads page in the top level of my github repo but the downloadable archives are in a `subdir/version/` format.  

This small patch makes `{{.Version}}` available for use in your template when generating the hyperlinks.

This is my template I am using now. 

```
  "TaskSettings": {
    "downloads-page": {
      "filename": "../../downloads.md",
      "outputFormat": "by-file-extension",
      "templateExtraVars": {
        "footer": "Generated by [goxc](https://github.com/laher/goxc)"
      },
      "templateFile": "",
      "templateText": "# Downloads\n\n{{.AppName}} downloads (version {{.Version}})\n\n{{range $k, $v := .Categories}}## {{$k}}\n\n{{range $v}} * [{{.Text}}](downloads/{{.Version}}/{{.RelativeLink}})\n{{end}}\n{{end}}\n\n{{.ExtraVars.footer}}"
    }
  }
}
```
