### PR TITLE
change default longDescription value to empty string

### DIFF
--- a/tasks/deb.go
+++ b/tasks/deb.go
@@ -170,7 +170,7 @@ func debBuild(dest platforms.Platform, tp TaskParams) error {
 			return err
 		}
 	}
-	longDescription := " "
+	longDescription := ""
 	if ldesc, keyExists := metadata["long-description"]; keyExists {
 		var err error
 		longDescription, err = typeutils.ToString(ldesc, "long-description")


### PR DESCRIPTION
having a single space produces an invalid control file.  For example, I get the following error trying to install my goxc-generated deb file:

```
dpkg: error processing archive imageproxy_0.2.2_amd64.deb (--install):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 7 package 'imageproxy':
 blank line in value of field 'Description'
```