### PR TITLE
include stderr in error message

### DIFF
--- a/tasks/codesign.go
+++ b/tasks/codesign.go
@@ -26,6 +26,7 @@ import (
 	// see https://groups.google.com/forum/?fromgroups=#!starred/golang-nuts/CY7o2aVNGZY
 	"github.com/laher/goxc/config"
 	"github.com/laher/goxc/core"
+	"github.com/laher/goxc/executils"
 	"github.com/laher/goxc/platforms"
 )
 
@@ -82,11 +83,6 @@ func codesignPlat(goos, arch string, binPath string, settings *config.Settings) 
 func signBinary(binPath string, id string) error {
 	cmd := exec.Command("codesign")
 	cmd.Args = append(cmd.Args, "-s", id, binPath)
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-	return nil
+
+	return executils.StartAndWait(cmd)
 }

--- a/tasks/tag.go
+++ b/tasks/tag.go
@@ -49,13 +49,7 @@ func tag(tp TaskParams) error {
 		if err != nil {
 			return err
 		}
-		err = cmd.Start()
-		if err != nil {
-			return err
-		} else {
-			err = cmd.Wait()
-			return err
-		}
+		return executils.StartAndWait(cmd)
 	} else {
 		return errors.New("Only 'git' is supported at this stage")
 	}

--- a/tasks/toolchain.go
+++ b/tasks/toolchain.go
@@ -115,15 +115,9 @@ func buildToolchain(goos string, arch string, settings *config.Settings) error {
 		log.Printf("Invoking '%v' from %s", executils.PrintableArgs(cmd.Args), cmd.Dir)
 	}
 	executils.RedirectIO(cmd)
-	err := cmd.Start()
+	err := executils.StartAndWait(cmd)
 	if err != nil {
-		log.Printf("Build toolchain: Launch error: %s", err)
-		return err
-	}
-	err = cmd.Wait()
-	if err != nil {
-		log.Printf("Build Toolchain: wait error: %s", err)
-		return err
+		log.Printf("Build toolchain: %s", err)
 	}
 	if settings.IsVerbose() {
 		log.Printf("Complete")


### PR DESCRIPTION
If a command runs but exits with an error, Go's default error message is basically useless.
It just says 'exit status 1'.  Well, gee, thanks.  However, most commands print out error information
to stderr, so we can use that to produce much more informative error messages.  The StartAndWait
function that I added does just this.