### PR TITLE
Minor fixes in Github Releases documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This is the good stuff, so let’s go from the top.
  * Write a local config file with your key info, ensuring that the key doesn’t end up in your git repo. 
 
 ```
-	goxc -wcl default publish-github -apikey=123456789012
+	goxc -wlc default publish-github -apikey=123456789012
 	echo ".goxc.local.json" >> .gitignore
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This is the good stuff, so let’s go from the top.
 
 ```
 	goxc -wcl default publish-github -apikey=123456789012
-	echo “.goxc.local.json” >> .gitignore
+	echo ".goxc.local.json" >> .gitignore
 ```
 
 *Note that you can put a dummy key into the commandline and edit the file later with the real key.*


### PR DESCRIPTION
I'm new to `goxc` so I'm just assuming `-wcl` should be `-wc`, like in the other examples.
I'm pretty sure the quotes should be normal quotes :)