### PR TITLE
Fix BuildSettings error variable shadowing bug.

### DIFF
--- a/config/json.go
+++ b/config/json.go
@@ -294,7 +294,8 @@ func loadSettingsSection(settingsSection map[string]interface{}) (settings Setti
 		case "ConfigVersion":
 			settings.GoxcConfigVersion, err = typeutils.ToString(v, k)
 		case "BuildSettings":
-			m, err := typeutils.ToMap(v, k)
+			var m map[string]interface{}
+			m, err = typeutils.ToMap(v, k)
 			if err == nil {
 				settings.BuildSettings, err = buildSettingsFromMap(m)
 				if err == nil {

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,6 +36,13 @@ func TestLoadSettings(t *testing.T) {
 	}
 	if !settings.IsVerbose() {
 		t.Fatalf("Verbose flag not set!")
+	}
+}
+
+func TestLoadJsonConfigsInvalid(t *testing.T) {
+	_, err := LoadJsonConfigs("", []string{filepath.Join("testdata", "invalid.goxc.json")}, false)
+	if err == nil {
+		t.Fatalf("invalid.goxc.json was loaded without an error, despite being invalid")
 	}
 }
 

--- a/config/testdata/invalid.goxc.json
+++ b/config/testdata/invalid.goxc.json
@@ -1,0 +1,19 @@
+{
+	"AppName": "example",
+	"ArtifactsDest": "release",
+	"OutPath": "foo",
+	"Tasks": [
+		"xc"
+	],
+	"Arch": "amd64",
+	"Os": "linux darwin",
+	"MainDirsExclude": "bar",
+	"ConfigVersion": "0.9",
+	"BuildSettings": {
+		"LdFlagsXVars": {
+			"Version": "baz.Version"
+		},
+		"Tags": "important",
+		"ExtraArgs": "-a"
+	}
+}


### PR DESCRIPTION
In `loadSettingsSection`, the returned error variable is predeclared in func signature. It's the variable that is being assigned and checked every time. But in "BuildSettings" case, that err variable was shadowed with another locally scoped err variable, so any non-nil error was being lost beyond that case block.

This fixes issue where errors in BuildSettings section of `.goxc.json` files were not being correctly detected by `goxc`.

For example, previously, having invalid BuildSettings section in `.goxc.json` would result in incorrect results that `goxc` would not catch:

```
goxc -pv=1.2.3 -os=linux darwin
[goxc:xc] 2015/07/01 14:01:16 Parallelizing xc for 2 platforms, using max 3 of 4 processors
[goxc:xc] 2015/07/01 14:01:28 Task xc succeeded
```

After this fix, the error in invalid `.goxc.json` is correctly detected:

```
goxc -pv=1.2.3 -os=linux darwin
[goxc] 2015/07/01 14:02:46 Configuration file error. ExtraArgs should be a json array, not a string
```