### PR TITLE
Made the github release upload URL dynamic

### DIFF
--- a/tasks/github/github_test.go
+++ b/tasks/github/github_test.go
@@ -36,11 +36,11 @@ func TestGetTagRelease(t *testing.T) {
 	if *apikey == "" {
 		t.Skip("api-key is required to run this integration test")
 	}
-	id, err := ghGetReleaseForTag(apihost, owner, *apikey, repo, tagName, isVerbose)
+	id, uploadURL, err := ghGetReleaseForTag(apihost, owner, *apikey, repo, tagName, isVerbose)
 	if err != nil {
 		t.Errorf("Error getting release %v", err)
 	}
-	t.Logf("ID: %s", id)
+	t.Logf("ID: %s uploadURL: %s", id, uploadURL)
 }
 
 func TestGetReleases(t *testing.T) {


### PR DESCRIPTION
goxc was hardcoding the githup upload URL to point to github.com.
This was breaking goxc release push on Github enterprise installation
where the URL would be customdomain.com rather than github.com.
This change reads the upload URL from the JSON message returned from
Github API and uses that dynamically rather than hardcoding it.