### PR TITLE
Fix backslashes in URLs on Windows

### DIFF
--- a/tasks/bintray.go
+++ b/tasks/bintray.go
@@ -186,6 +186,7 @@ func walkFunc(fullPath string, fi2 os.FileInfo, err error, reportFilename string
 	versionDir := filepath.Join(tp.OutDestRoot, tp.Settings.GetFullVersionName())
 
 	relativePath := strings.Replace(fullPath, versionDir, "", -1)
+	relativePath = strings.Replace(relativePath, "\\", "/", -1)
 	relativePath = strings.TrimPrefix(relativePath, "/")
 	fmt.Printf("relative path %s, full path %s\n", relativePath, fullPath)
 

--- a/tasks/downloads-page.go
+++ b/tasks/downloads-page.go
@@ -159,6 +159,7 @@ func downloadsWalkFunc(fullPath string, Version string, fi2 os.FileInfo, err err
 
 	versionDir := filepath.Join(tp.OutDestRoot, tp.Settings.GetFullVersionName())
 	relativePath := strings.Replace(fullPath, versionDir, "", -1)
+	relativePath = strings.Replace(relativePath, "\\", "/", -1)
 	relativePath = strings.TrimPrefix(relativePath, "/")
 	text := fi2.Name()
 	if format == "markdown" {

--- a/tasks/github/github.go
+++ b/tasks/github/github.go
@@ -134,6 +134,7 @@ func ghWalkFunc(fullPath string, fi2 os.FileInfo, err error, reportFilename stri
 	excludeGlobs := core.ParseCommaGlobs(excludeResources)
 	versionDir := filepath.Join(tp.OutDestRoot, tp.Settings.GetFullVersionName())
 	relativePath := strings.Replace(fullPath, versionDir, "", -1)
+	relativePath = strings.Replace(relativePath, "\\", "/", -1)
 	relativePath = strings.TrimPrefix(relativePath, "/")
 	//fmt.Printf("relative path %s, full path %s\n", relativePath, fullPath)
 	if fi2.IsDir() {

--- a/tasks/http.go
+++ b/tasks/http.go
@@ -95,7 +95,9 @@ func httpWalk(config *httpTaskConfig, fullPath string, fi os.FileInfo, err error
 		return nil
 	}
 	versionDir := filepath.Join(tp.OutDestRoot, tp.Settings.GetFullVersionName())
-	relativePath := strings.TrimPrefix(strings.Replace(fullPath, versionDir, "", -1), "/")
+	relativePath := strings.Replace(fullPath, versionDir, "", -1)
+	relativePath = strings.Replace(relativePath, "\\", "/", -1)
+	relativePath = strings.TrimPrefix(relativePath, "/")
 	if !tp.Settings.IsQuiet() {
 		log.Printf("Considering %s", relativePath)
 	}


### PR DESCRIPTION
Convert paths to use to forward slashes

Fixes errors like this:
```
$ goxc bintray
relative path \.goxc-temp\control.tar.gz, full path Z:\golang\bin\packer-post-processor-virtualbox-to-hyperv-xc\0.1.0\.goxc-temp\control.tar.gz
[goxc:bintray] 2016/03/24 12:04:44 Adding Header - Content-Length: 254
[goxc:bintray] 2016/03/24 12:04:44 Adding Header - Content-Type: application/x-gzip
[goxc:bintray] 2016/03/24 12:04:44 PUT to https://api.bintray.com//content/dwickern/packer-plugins/packer-post-processor-virtualbox-to-hyperv/0.1.0/\.goxc-temp\control.tar.gz
[goxc:bintray] 2016/03/24 12:04:44 Http response received
[goxc:bintray] 2016/03/24 12:04:44 Error code: 400 Bad Request
[goxc:bintray] 2016/03/24 12:04:44 Error body:
[goxc:bintray] 2016/03/24 12:04:44 Stopping after 'bintray' failed with error 'Error code: 400, message: 400 Bad Request'
[goxc] 2016/03/24 12:04:44 RunTasks error: Error code: 400, message: 400 Bad Request
```