### PR TITLE
Add rice-append task

### DIFF
--- a/tasks/rice-append.go
+++ b/tasks/rice-append.go
@@ -1,0 +1,81 @@
+package tasks
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/laher/goxc/config"
+	"github.com/laher/goxc/core"
+	"github.com/laher/goxc/executils"
+)
+
+const riceNotFound = `Could not find 'rice' executable on $PATH.
+Please ensure you have installed it:
+
+go get -u github.com/GeertJohan/go.rice/rice
+
+Error: %v`
+
+var riceAppendTask = Task{
+	TASK_RICE_APPEND,
+	"Append embedded resources to the binary using go.rice.",
+	runTaskRiceAppend,
+	map[string]interface{}{
+		"import-paths": []string{},
+	}}
+
+//runs automatically
+func init() {
+	Register(riceAppendTask)
+}
+
+func runTaskRiceAppend(tp TaskParams) (err error) {
+	ricePath, err := exec.LookPath("rice")
+	if err != nil {
+		return fmt.Errorf(riceNotFound, err)
+	}
+	for _, dest := range tp.DestPlatforms {
+		for _, mainDir := range tp.MainDirs {
+			var exeName string
+			if len(tp.MainDirs) == 1 {
+				exeName = tp.Settings.AppName
+			} else {
+				exeName = filepath.Base(mainDir)
+
+			}
+			binPath, err := core.GetAbsoluteBin(dest.Os, dest.Arch, tp.Settings.AppName, exeName, tp.WorkingDirectory, tp.Settings.GetFullVersionName(), tp.Settings.OutPath, tp.Settings.ArtifactsDest)
+
+			if err != nil {
+				return err
+			}
+			if err = riceAppendPlat(dest.Os, dest.Arch, binPath, ricePath, tp.Settings); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func riceAppendPlat(goos, arch string, binPath string, ricePath string, settings *config.Settings) error {
+	importPaths := settings.GetTaskSettingStringSlice("rice-append", "import-paths")
+	if err := riceAppend(binPath, ricePath, importPaths); err != nil {
+		log.Printf("rice-append failed for %s: %s", binPath, err)
+		return err
+	}
+	if !settings.IsQuiet() {
+		log.Printf("rice-append successful for: %s", binPath)
+	}
+	return nil
+}
+
+func riceAppend(binPath string, ricePath string, importPaths []string) error {
+	cmd := exec.Command(ricePath)
+	cmd.Args = append(cmd.Args, "append", fmt.Sprintf("--exec=%s", binPath))
+	for _, importPath := range importPaths {
+		cmd.Args = append(cmd.Args, fmt.Sprintf("--import-path=%s", importPath))
+	}
+
+	return executils.StartAndWait(cmd)
+}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -42,9 +42,10 @@ const (
 	TASK_GO_TEST = "go-test"
 	TASK_GO_FMT  = "go-fmt"
 
-	TASK_GO_INSTALL = "go-install"
-	TASK_XC         = "xc"
-	TASK_CODESIGN   = "codesign"
+	TASK_GO_INSTALL  = "go-install"
+	TASK_XC          = "xc"
+	TASK_CODESIGN    = "codesign"
+	TASK_RICE_APPEND = "rice-append"
 
 	TASK_COPY_RESOURCES = "copy-resources"
 	TASK_ARCHIVE_ZIP    = "archive-zip"
@@ -78,7 +79,7 @@ var (
 	TASKS_PKG_SOURCE                  = []string{TASK_DEB_SOURCE}
 	TASKS_VALIDATE                    = []string{TASK_GO_VET, TASK_GO_TEST}
 	TASKS_DEFAULT                     = append(append(append([]string{}, TASKS_VALIDATE...), TASKS_COMPILE...), TASKS_PACKAGE...)
-	TASKS_OTHER                       = []string{TASK_BUILD_TOOLCHAIN, TASK_GO_FMT, TASK_PUBLISH_GITHUB}
+	TASKS_OTHER                       = []string{TASK_BUILD_TOOLCHAIN, TASK_GO_FMT, TASK_RICE_APPEND, TASK_PUBLISH_GITHUB}
 	TASKS_ALL                         = append(append([]string{}, TASKS_OTHER...), TASKS_DEFAULT...)
 	TASK_ALIASES_FOR_MERGING_SETTINGS = map[string][]string{TASKALIAS_PKG_BUILD: TASKS_PKG_BUILD, TASKALIAS_PKG_SOURCE: TASKS_PKG_SOURCE, TASKALIAS_DEBS: TASKS_DEBS}
 


### PR DESCRIPTION
Adds a task to call `rice append` on the build result, allowing
embedding of resources into the binary.