### PR TITLE
Add deb task configuration allowing the auto-inclusion of resources

### DIFF
--- a/tasks/deb-dev.go
+++ b/tasks/deb-dev.go
@@ -131,7 +131,9 @@ func debDevBuild(tp TaskParams) error {
 	build := debgen.NewBuildParams()
 	build.DestDir = debDir
 	build.TmpDir = tmpDir
-	build.Init()
+	if err = build.Init(); err != nil {
+		return err
+	}
 	build.IsRmtemp = rmtemp
 	var ctrl *deb.Control
 	//Read control data. If control file doesnt exist, use parameters ...

--- a/tasks/deb-source.go
+++ b/tasks/deb-source.go
@@ -90,6 +90,7 @@ func init() {
 			},
 			"rmtemp":              true,
 			"go-sources-dir":      ".",
+			"resources-dir":       "",
 			"other-mappped-files": map[string]interface{}{},
 		}})
 }
@@ -216,8 +217,15 @@ func debSourceBuild(tp TaskParams) (err error) {
 	build := debgen.NewBuildParams()
 	build.DestDir = debDir
 	build.TmpDir = tmpDir
-	build.Init()
+	if err = build.Init(); err != nil {
+		return err
+	}
 	build.IsRmtemp = rmtemp
+
+	if resDir := tp.Settings.GetTaskSettingString(TASK_DEB_GEN, "resources-dir"); resDir != "" {
+		build.ResourcesDir = resDir
+	}
+
 	var ctrl *deb.Control
 	//Read control data. If control file doesnt exist, use parameters ...
 	fi, err := os.Open(filepath.Join(build.DebianDir, "control"))

--- a/tasks/deb.go
+++ b/tasks/deb.go
@@ -41,8 +41,8 @@ func init() {
 		runTaskDebGen,
 		map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"maintainer":      "unknown",
-				"maintainerEmail": "unknown@example.com",
+				"maintainer":       "unknown",
+				"maintainer-email": "unknown@example.com",
 			},
 			"metadata-deb": map[string]interface{}{"Depends": "",
 				"Build-Depends": "debhelper (>=4.0.0), golang-go, gcc",
@@ -50,6 +50,7 @@ func init() {
 			"rmtemp":              true,
 			"armarch":             "",
 			"go-sources-dir":      ".",
+			"resources-dir":       "",
 			"other-mappped-files": map[string]interface{}{},
 			"bin-dir":             "/usr/bin",
 		},
@@ -204,8 +205,15 @@ func debBuild(dest platforms.Platform, tp TaskParams) error {
 	build := debgen.NewBuildParams()
 	build.DestDir = debDir
 	build.TmpDir = tmpDir
-	build.Init()
+	if err = build.Init(); err != nil {
+		return err
+	}
 	build.IsRmtemp = rmtemp
+
+	if resDir := tp.Settings.GetTaskSettingString(TASK_DEB_GEN, "resources-dir"); resDir != "" {
+		build.ResourcesDir = resDir
+	}
+
 	var ctrl *deb.Control
 	//Read control data. If control file doesnt exist, use parameters ...
 	fi, err := os.Open(filepath.Join(build.DebianDir, "control"))


### PR DESCRIPTION
Allows the use of pre/post{inst,rm}, etc scripts.  The `resources-dir`
task setting should be set to the parent directory of a `debian` dir
containing the resources.
