### PR TITLE
Fix README markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Be careful if you want to build a project with multiple executables. You need to
 
 ```
 "OutPath": "{{.Dest}}{{.PS}}{{.AppName}}{{.PS}}{{.Version}}{{.PS}}{{.ExeName}}_{{.Version}}_{{.Os}}_{{.Arch}}{{.Ext}}"
-``
+```
 
 Configuration file
 -----------------


### PR DESCRIPTION
The current README formatting is a bit messed up because of the unmatching triple ``` introduced in https://github.com/laher/goxc/commit/076d865a2399dcc9a66c9d7d1e0567dc401bee3f